### PR TITLE
Count-only and regex searches

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ Output MARC data to the console in a line delimited format (`marcli` automatical
 ./marcli -file data/test_10.xml
 ```
 
-Extract MARC records on file that contain the string "wildlife"
+You can use the `-match` parameter to get only the records that match a given string, for example the code below extracts MARC records that contain the string "wildlife"
+
 ```
 ./marcli -file data/test_10.mrc -match wildlife
 ```
@@ -42,10 +43,16 @@ Extracts MARC records on file that contain the string "wildlife" but outputs onl
 ./marcli -file data/test_10.mrc -match wildlife -fields LDR,010,040,245a,650
 ```
 
+The `-matchRegEx` parameter can be used to pass a regular expression instead of a value to select the records that will be matched, for example the following will print only those records that have values that look like dates for March 2006 (03-\d\d-06):
+
+```
+./marcli -file data/test_10.xml -matchRegEx '.*03-\d\d-06.*'
+```
+
 The `-matchFields` parameter can be used to limit the fields where the match will be made:
 
 ```
-./marcli -file=data/test_10.mrc -match=web -matchFields=530
+./marcli -file data/test_10.mrc -match web -matchFields 530
 ````
 
 You can also use the `exclude` option to indicate fields to exclude from the output (notice that only full fields are supported here, e.g. 970 is accepted but not 970a)

--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ You can also filter based on the presence of certain fields in the MARC record (
 
 By default the output is in Mnemonic MARC (`.mrk`), which is a human readable format. You can use the `format` parameter to output MARC XML, MARC JSON, or MARC binary instead. Notice that not all the features are available in all the formats.
 
+You can use `count-only` as the `format` if you only want a count of the number of records on the file. If you use the `match` parameter it will report only the number of records that match the criteria.
+
 You can also pass `start` and `count` parameters to output only a range of MARC records.
 
 

--- a/cmd/marcli/json.go
+++ b/cmd/marcli/json.go
@@ -42,7 +42,7 @@ func toJson(params ProcessFileParams) error {
 		if i++; i < start {
 			continue
 		}
-		if r.Contains(params.searchValue, params.searchFields) && r.HasFields(params.hasFields) {
+		if r.Contains(params.searchValue, params.searchRegEx, params.searchFields) && r.HasFields(params.hasFields) {
 			if out > 0 {
 				fmt.Printf(",\r\n")
 			} else {

--- a/cmd/marcli/main.go
+++ b/cmd/marcli/main.go
@@ -9,17 +9,18 @@ import (
 	"github.com/hectorcorrea/marcli/pkg/marc"
 )
 
-var fileName, search, searchFields, fields, exclude, format, hasFields string
+var fileName, search, searchRegEx, searchFields, fields, exclude, format, hasFields string
 var start, count int
 var debug bool
 
 func init() {
 	flag.StringVar(&fileName, "file", "", "MARC file to process. Required.")
 	flag.StringVar(&search, "match", "", "String that must be present in the content of the record, case insensitive.")
+	flag.StringVar(&searchRegEx, "matchRegEx", "", "A regular expression to match the record.")
 	flag.StringVar(&searchFields, "matchFields", "", "Comma delimited list of fields to search, used when match parameter is indicated, defaults to all fields.")
 	flag.StringVar(&fields, "fields", "", "Comma delimited list of fields to output.")
 	flag.StringVar(&exclude, "exclude", "", "Comma delimited list of fields to exclude from the output.")
-	flag.StringVar(&format, "format", "mrk", "Output format. Accepted values: mrk, mrc, xml, json, or solr.")
+	flag.StringVar(&format, "format", "mrk", "Output format. Accepted values: mrk, mrc, xml, json, solr, or count-only.")
 	flag.IntVar(&start, "start", 1, "Number of first record to load")
 	flag.IntVar(&count, "count", -1, "Total number of records to load (-1 no limit)")
 	flag.StringVar(&hasFields, "hasFields", "", "Comma delimited list of fields that must be present in the record.")
@@ -50,10 +51,10 @@ func main() {
 	}
 
 	var err error
-	if format == "mrc" {
-		err = toMrc(params)
-	} else if format == "mrk" {
+	if format == "mrk" || format == "count-only" {
 		err = toMrk(params)
+	} else if format == "mrc" {
+		err = toMrc(params)
 	} else if format == "json" {
 		err = toJson(params)
 	} else if format == "solr" {
@@ -61,7 +62,7 @@ func main() {
 	} else if format == "xml" {
 		err = toXML(params)
 	} else {
-		err = errors.New("Invalid format")
+		err = errors.New("invalid format")
 	}
 	if err != nil {
 		panic(err)

--- a/cmd/marcli/main.go
+++ b/cmd/marcli/main.go
@@ -36,7 +36,9 @@ func main() {
 
 	params := ProcessFileParams{
 		filename:     fileName,
+		format:       format,
 		searchValue:  strings.ToLower(search),
+		searchRegEx:  searchRegEx,
 		searchFields: searchFieldsFromString(searchFields),
 		filters:      marc.NewFieldFilters(fields),
 		exclude:      marc.NewFieldFilters(exclude),
@@ -48,6 +50,10 @@ func main() {
 
 	if len(params.filters.Fields) > 0 && len(params.exclude.Fields) > 0 {
 		panic("Cannot specify fields and exclude at the same time.")
+	}
+
+	if params.searchValue != "" && params.searchRegEx != "" {
+		panic("Cannot specify match and matchRegEx at the same time.")
 	}
 
 	var err error
@@ -80,6 +86,9 @@ NOTES:
 By default marcli searches in all the fields for each record, you can use
 the matchFields parameter to limit the search to only certain fields (subfields
 are not supported in matchFields, i.e. 245 is OK, 245a is not)
+
+    The matchRegEx parameter can be used to filter records based on a regular expression
+(e.g. '.*03-\d\d-06.*' to get records with dates from March 2006)
 
     The hasFields parameter is used to filter records based on the presence
 of certain fields on the record (regardless of their value).

--- a/cmd/marcli/mrc.go
+++ b/cmd/marcli/mrc.go
@@ -39,7 +39,7 @@ func toMrc(params ProcessFileParams) error {
 			continue
 		}
 
-		if r.Contains(params.searchValue, params.searchFields) && r.HasFields(params.hasFields) {
+		if r.Contains(params.searchValue, params.searchRegEx, params.searchFields) && r.HasFields(params.hasFields) {
 			fmt.Printf("%s", r.Raw())
 			if out++; out == count {
 				break

--- a/cmd/marcli/mrk.go
+++ b/cmd/marcli/mrk.go
@@ -21,7 +21,7 @@ func toMrk(params ProcessFileParams) error {
 	}
 	defer file.Close()
 
-	var i, out int
+	var i, out, recordCount int
 	marc := marc.NewMarcFile(file)
 	for marc.Scan() {
 
@@ -46,7 +46,8 @@ func toMrk(params ProcessFileParams) error {
 			continue
 		}
 
-		if r.Contains(params.searchValue, params.searchFields) && r.HasFields(params.hasFields) {
+		if r.Contains(params.searchValue, params.searchRegEx, params.searchFields) && r.HasFields(params.hasFields) {
+			recordCount += 1
 			str := ""
 			if params.filters.IncludeLeader() {
 				str += fmt.Sprintf("%s\r\n", r.Leader)
@@ -55,7 +56,10 @@ func toMrk(params ProcessFileParams) error {
 				str += fmt.Sprintf("%s\r\n", field)
 			}
 			if str != "" {
-				fmt.Printf("%s\r\n", str)
+				// Print the details of the record
+				if format == "mrk" {
+					fmt.Printf("%s\r\n", str)
+				}
 				if out++; out == count {
 					break
 				}
@@ -63,5 +67,9 @@ func toMrk(params ProcessFileParams) error {
 		}
 	}
 
+	// Print the count of records only
+	if format == "count-only" {
+		fmt.Printf("%d\r\n", recordCount)
+	}
 	return marc.Err()
 }

--- a/cmd/marcli/mrk.go
+++ b/cmd/marcli/mrk.go
@@ -57,7 +57,7 @@ func toMrk(params ProcessFileParams) error {
 			}
 			if str != "" {
 				// Print the details of the record
-				if format == "mrk" {
+				if params.format == "mrk" {
 					fmt.Printf("%s\r\n", str)
 				}
 				if out++; out == count {
@@ -68,7 +68,7 @@ func toMrk(params ProcessFileParams) error {
 	}
 
 	// Print the count of records only
-	if format == "count-only" {
+	if params.format == "count-only" {
 		fmt.Printf("%d\r\n", recordCount)
 	}
 	return marc.Err()

--- a/cmd/marcli/processFileParams.go
+++ b/cmd/marcli/processFileParams.go
@@ -7,7 +7,9 @@ import (
 type ProcessFileParams struct {
 	filename     string
 	searchValue  string
+	searchRegEx  string
 	searchFields []string
+	format       string
 	filters      marc.FieldFilters
 	exclude      marc.FieldFilters
 	start        int

--- a/cmd/marcli/solr.go
+++ b/cmd/marcli/solr.go
@@ -97,7 +97,7 @@ func toSolr(params ProcessFileParams) error {
 		if i++; i < start {
 			continue
 		}
-		if r.Contains(params.searchValue, params.searchFields) && r.HasFields(params.hasFields) {
+		if r.Contains(params.searchValue, params.searchRegEx, params.searchFields) && r.HasFields(params.hasFields) {
 			if out > 0 {
 				fmt.Printf(",\r\n")
 			} else {

--- a/cmd/marcli/xml.go
+++ b/cmd/marcli/xml.go
@@ -70,7 +70,7 @@ func toXML(params ProcessFileParams) error {
 			continue
 		}
 
-		if r.Contains(params.searchValue, params.searchFields) && r.HasFields(params.hasFields) {
+		if r.Contains(params.searchValue, params.searchRegEx, params.searchFields) && r.HasFields(params.hasFields) {
 			str, err := recordToXML(r, params)
 			if err != nil {
 				if params.debug {

--- a/pkg/marc/field.go
+++ b/pkg/marc/field.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"regexp"
 	"strings"
 )
 
@@ -88,7 +89,7 @@ func (f Field) IsControlField() bool {
 	return strings.HasPrefix(f.Tag, "00")
 }
 
-// Contains returns true if the field contains the passed string.
+// Contains returns true if the field contains the passed string or matches the regex.
 func (f Field) Contains(str string, regEx string) bool {
 	if str != "" {
 		return f.containsValue(str)
@@ -112,11 +113,23 @@ func (f Field) containsValue(str string) bool {
 }
 
 func (f Field) containsRegEx(regEx string) bool {
-	// TODO: implement the regex search
-	// re := regexp.MustCompile(regEx)
-	// matches := re.FindStringSubmatch(search)
-	// fmt.Printf("%#v\r\n", matches)
-	panic("regex search has not been implemented")
+	re := regexp.MustCompile(regEx)
+
+	if f.IsControlField() {
+		matches := re.FindStringSubmatch(f.Value)
+		// if matches != nil {
+		// 	fmt.Printf("Control field match %s: %#v\r\n", f.Tag, matches)
+		// }
+		return matches != nil
+	}
+
+	for _, sub := range f.SubFields {
+		matches := re.FindStringSubmatch(sub.Value)
+		if matches != nil {
+			// fmt.Printf("Field match %s: %#v\r\n", f.Tag, matches)
+			return true
+		}
+	}
 	return false
 }
 

--- a/pkg/marc/field.go
+++ b/pkg/marc/field.go
@@ -89,7 +89,15 @@ func (f Field) IsControlField() bool {
 }
 
 // Contains returns true if the field contains the passed string.
-func (f Field) Contains(str string) bool {
+func (f Field) Contains(str string, regEx string) bool {
+	if str != "" {
+		return f.containsValue(str)
+	} else {
+		return f.containsRegEx(regEx)
+	}
+}
+
+func (f Field) containsValue(str string) bool {
 	str = strings.ToLower(str)
 	if f.IsControlField() {
 		return strings.Contains(strings.ToLower(f.Value), str)
@@ -100,6 +108,15 @@ func (f Field) Contains(str string) bool {
 			return true
 		}
 	}
+	return false
+}
+
+func (f Field) containsRegEx(regEx string) bool {
+	// TODO: implement the regex search
+	// re := regexp.MustCompile(regEx)
+	// matches := re.FindStringSubmatch(search)
+	// fmt.Printf("%#v\r\n", matches)
+	panic("regex search has not been implemented")
 	return false
 }
 

--- a/pkg/marc/field_test.go
+++ b/pkg/marc/field_test.go
@@ -133,6 +133,7 @@ func TestContains(t *testing.T) {
 		name   string
 		input  Field
 		arg    string
+		regEx  string
 		result bool
 	}{
 		{
@@ -219,7 +220,8 @@ func TestContains(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if tt.input.Contains(tt.arg) != tt.result {
+			// TODO: Add test for regEx searches
+			if tt.input.Contains(tt.arg, tt.regEx) != tt.result {
 				t.Errorf("expected Contains() call on %v to return %v for %v", tt.input, tt.result, tt.arg)
 			}
 		})

--- a/pkg/marc/record.go
+++ b/pkg/marc/record.go
@@ -13,11 +13,11 @@ type Record struct {
 	Leader Leader
 }
 
-// Contains returns true if Record contains the value passed.
+// Contains returns true if Record contains the value passed or matches the regEx passed.
 // If searchFieldList is an empty array it searches in all fields for the record
 // otherwise the search is limited to only the fields in the array.
-func (r Record) Contains(searchValue string, searchFieldsList []string) bool {
-	if searchValue == "" {
+func (r Record) Contains(searchValue string, searchRegEx string, searchFieldsList []string) bool {
+	if searchValue == "" && searchRegEx == "" {
 		return true
 	}
 
@@ -33,7 +33,7 @@ func (r Record) Contains(searchValue string, searchFieldsList []string) bool {
 	}
 
 	for _, field := range searchFields {
-		if field.Contains(searchValue) {
+		if field.Contains(searchValue, searchRegEx) {
 			return true
 		}
 	}

--- a/pkg/marc/record_test.go
+++ b/pkg/marc/record_test.go
@@ -16,6 +16,7 @@ func TestRecordContains(t *testing.T) {
 	containsTests := []struct {
 		name             string
 		searchValue      string
+		searchRegEx      string
 		searchFieldsList []string
 		result           bool
 	}{
@@ -28,7 +29,7 @@ func TestRecordContains(t *testing.T) {
 	}
 
 	for _, tt := range containsTests {
-		got := record.Contains(tt.searchValue, tt.searchFieldsList)
+		got := record.Contains(tt.searchValue, tt.searchRegEx, tt.searchFieldsList)
 		if !got == tt.result {
 			t.Errorf("expected record not to contain %q", tt.searchValue)
 		}


### PR DESCRIPTION
Adds the ability to return the count of records only (via the `format` parameter) and the ability to use a regular expression on searches (via the `matchRegEx` parameter)