### PR TITLE
Use LF as the line delimiter by default. Allow CRLF via parameter.

### DIFF
--- a/cmd/marcli/json.go
+++ b/cmd/marcli/json.go
@@ -44,22 +44,21 @@ func toJson(params ProcessFileParams) error {
 		}
 		if r.Contains(params.searchValue, params.searchRegEx, params.searchFields) && r.HasFields(params.hasFields) {
 			if out > 0 {
-				fmt.Printf(",\r\n")
+				fmt.Printf(",%s", params.NewLine())
 			} else {
-				fmt.Printf("\r\n")
+				fmt.Printf("%s", params.NewLine())
 			}
 			b, err := json.Marshal(r.Filter(params.filters, params.exclude))
 			if err != nil {
-				fmt.Printf("%s\r\n", err)
+				fmt.Printf("%s%s", err, params.NewLine())
 			}
-			// fmt.Printf("{ \"record\": %s}\r\n", b)
 			fmt.Printf("%s", b)
 			if out++; out == count {
 				break
 			}
 		}
 	}
-	fmt.Printf("\r\n]\r\n")
+	fmt.Printf("%s]%s", params.NewLine(), params.NewLine())
 
 	return marc.Err()
 }

--- a/cmd/marcli/main.go
+++ b/cmd/marcli/main.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hectorcorrea/marcli/pkg/marc"
 )
 
-var fileName, search, searchRegEx, searchFields, fields, exclude, format, hasFields string
+var fileName, search, searchRegEx, searchFields, fields, exclude, format, hasFields, newLine string
 var start, count int
 var debug bool
 
@@ -21,10 +21,11 @@ func init() {
 	flag.StringVar(&fields, "fields", "", "Comma delimited list of fields to output.")
 	flag.StringVar(&exclude, "exclude", "", "Comma delimited list of fields to exclude from the output.")
 	flag.StringVar(&format, "format", "mrk", "Output format. Accepted values: mrk, mrc, xml, json, solr, or count-only.")
-	flag.IntVar(&start, "start", 1, "Number of first record to load")
-	flag.IntVar(&count, "count", -1, "Total number of records to load (-1 no limit)")
+	flag.IntVar(&start, "start", 1, "Number of first record to load.")
+	flag.IntVar(&count, "count", -1, "Total number of records to load (-1 no limit).")
 	flag.StringVar(&hasFields, "hasFields", "", "Comma delimited list of fields that must be present in the record.")
-	flag.BoolVar(&debug, "debug", false, "When true it does not stop on errors")
+	flag.BoolVar(&debug, "debug", false, "When true it does not stop on errors.")
+	flag.StringVar(&newLine, "newLine", "LF", "Character(s) to use to indicate new lines. Valid values LF or CRLF.")
 	flag.Parse()
 }
 
@@ -46,6 +47,7 @@ func main() {
 		count:        count,
 		hasFields:    marc.NewFieldFilters(hasFields),
 		debug:        debug,
+		newLine:      newLine,
 	}
 
 	if len(params.filters.Fields) > 0 && len(params.exclude.Fields) > 0 {
@@ -76,10 +78,10 @@ func main() {
 }
 
 func showSyntax() {
-	fmt.Printf("marcli parameters:\r\n")
-	fmt.Printf("\r\n")
+	fmt.Println("marcli parameters:")
+	fmt.Println()
 	flag.PrintDefaults()
-	fmt.Printf("\r\n")
+	fmt.Println()
 	fmt.Printf(`
 NOTES:
 	The match parameter is used to filter records based on their content.
@@ -95,8 +97,8 @@ of certain fields on the record (regardless of their value).
 
 	You can only use the fields or exclude parameter, but not both.
 `)
-	fmt.Printf("\r\n")
-	fmt.Printf("\r\n")
+	fmt.Println()
+	fmt.Println()
 }
 
 func searchFieldsFromString(searchFieldsString string) []string {

--- a/cmd/marcli/mrk.go
+++ b/cmd/marcli/mrk.go
@@ -31,10 +31,10 @@ func toMrk(params ProcessFileParams) error {
 		}
 
 		if err != nil {
-			str := "== RECORD WITH ERROR STARTS HERE\n"
-			str += "ERROR:\n" + err.Error() + "\n"
-			str += r.DebugString() + "\n"
-			str += "== RECORD WITH ERROR ENDS HERE\n\n"
+			str := "== RECORD WITH ERROR STARTS HERE" + params.NewLine()
+			str += "ERROR:" + params.NewLine() + err.Error() + params.NewLine()
+			str += r.DebugString() + params.NewLine()
+			str += "== RECORD WITH ERROR ENDS HERE" + params.NewLine() + params.NewLine()
 			fmt.Print(str)
 			if params.debug {
 				continue
@@ -50,15 +50,15 @@ func toMrk(params ProcessFileParams) error {
 			recordCount += 1
 			str := ""
 			if params.filters.IncludeLeader() {
-				str += fmt.Sprintf("%s\r\n", r.Leader)
+				str += fmt.Sprintf("%s%s", r.Leader, params.NewLine())
 			}
 			for _, field := range r.Filter(params.filters, params.exclude) {
-				str += fmt.Sprintf("%s\r\n", field)
+				str += fmt.Sprintf("%s%s", field, params.NewLine())
 			}
 			if str != "" {
 				// Print the details of the record
 				if params.format == "mrk" {
-					fmt.Printf("%s\r\n", str)
+					fmt.Printf("%s%s", str, params.NewLine())
 				}
 				if out++; out == count {
 					break
@@ -69,7 +69,7 @@ func toMrk(params ProcessFileParams) error {
 
 	// Print the count of records only
 	if params.format == "count-only" {
-		fmt.Printf("%d\r\n", recordCount)
+		fmt.Printf("%d%s", recordCount, params.NewLine())
 	}
 	return marc.Err()
 }

--- a/cmd/marcli/processFileParams.go
+++ b/cmd/marcli/processFileParams.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"strings"
+
 	"github.com/hectorcorrea/marcli/pkg/marc"
 )
 
@@ -16,8 +18,19 @@ type ProcessFileParams struct {
 	count        int
 	hasFields    marc.FieldFilters
 	debug        bool
+	newLine      string
 }
 
 func (p ProcessFileParams) HasFilters() bool {
 	return len(p.filters.Fields) > 0 || len(p.exclude.Fields) > 0
+}
+
+func (p ProcessFileParams) NewLine() string {
+	if strings.ToUpper(newLine) == "CRLF" {
+		// Windows style
+		return "\r\n"
+	} else {
+		// Unix style
+		return "\n"
+	}
 }

--- a/cmd/marcli/solr.go
+++ b/cmd/marcli/solr.go
@@ -99,14 +99,14 @@ func toSolr(params ProcessFileParams) error {
 		}
 		if r.Contains(params.searchValue, params.searchRegEx, params.searchFields) && r.HasFields(params.hasFields) {
 			if out > 0 {
-				fmt.Printf(",\r\n")
+				fmt.Printf(",%s", params.NewLine())
 			} else {
-				fmt.Printf("\r\n")
+				fmt.Printf("%s", params.NewLine())
 			}
 			doc := NewSolrDocument(r)
 			b, err := json.Marshal(doc)
 			if err != nil {
-				fmt.Printf("%s\r\n", err)
+				fmt.Printf("%s%s", err, params.NewLine())
 			}
 			fmt.Printf("%s", b)
 			if out++; out == count {
@@ -114,7 +114,7 @@ func toSolr(params ProcessFileParams) error {
 			}
 		}
 	}
-	fmt.Printf("\r\n]\r\n")
+	fmt.Printf("%s]%s", params.NewLine(), params.NewLine())
 
 	return marc.Err()
 }

--- a/cmd/marcli/xml.go
+++ b/cmd/marcli/xml.go
@@ -79,7 +79,7 @@ func toXML(params ProcessFileParams) error {
 				}
 				panic(err)
 			}
-			fmt.Printf("%s\r\n", str)
+			fmt.Printf("%s%s", str, params.NewLine())
 			if out++; out == count {
 				break
 			}

--- a/pkg/marc/field.go
+++ b/pkg/marc/field.go
@@ -118,7 +118,7 @@ func (f Field) containsRegEx(regEx string) bool {
 	if f.IsControlField() {
 		matches := re.FindStringSubmatch(f.Value)
 		// if matches != nil {
-		// 	fmt.Printf("Control field match %s: %#v\r\n", f.Tag, matches)
+		// 	fmt.Printf("Control field match %s: %#v\n", f.Tag, matches)
 		// }
 		return matches != nil
 	}
@@ -126,7 +126,7 @@ func (f Field) containsRegEx(regEx string) bool {
 	for _, sub := range f.SubFields {
 		matches := re.FindStringSubmatch(sub.Value)
 		if matches != nil {
-			// fmt.Printf("Field match %s: %#v\r\n", f.Tag, matches)
+			// fmt.Printf("Field match %s: %#v\n", f.Tag, matches)
 			return true
 		}
 	}

--- a/pkg/marc/filters.go
+++ b/pkg/marc/filters.go
@@ -57,15 +57,15 @@ func NewFieldFilter(fieldStr string) (FieldFilter, error) {
 }
 
 func (filters FieldFilters) String() string {
-	s := "Filters {\r\n"
+	s := "Filters {\n"
 	for _, field := range filters.Fields {
 		if field.Subfields == "" {
-			s += fmt.Sprintf("\tTag: %s\r\n", field.Tag)
+			s += fmt.Sprintf("\tTag: %s\n", field.Tag)
 		} else {
-			s += fmt.Sprintf("\tTag: %s subfields: %s\r\n", field.Tag, field.Subfields)
+			s += fmt.Sprintf("\tTag: %s subfields: %s\n", field.Tag, field.Subfields)
 		}
 	}
-	s += "}\r\n"
+	s += "}\n"
 	return s
 }
 

--- a/pkg/marc/filters_test.go
+++ b/pkg/marc/filters_test.go
@@ -123,7 +123,7 @@ func TestFieldFiltersString(t *testing.T) {
 
 	fieldFilters := FieldFilters{Fields: []FieldFilter{{Tag: "LDR", Subfields: ""}, {Tag: "245", Subfields: "ahc"}}}
 
-	want := "Filters {\r\n\tTag: LDR\r\n\tTag: 245 subfields: ahc\r\n}\r\n"
+	want := "Filters {\n\tTag: LDR\n\tTag: 245 subfields: ahc\n}\n"
 	got := fieldFilters.String()
 
 	if want != got {

--- a/pkg/marc/record.go
+++ b/pkg/marc/record.go
@@ -67,9 +67,9 @@ func (r Record) String() string {
 
 func (r Record) DebugString() string {
 	str := "PARSED:\n"
-	str += fmt.Sprintf("%s\r\n", r.Leader)
+	str += fmt.Sprintf("%s\n", r.Leader)
 	for _, field := range r.Fields {
-		str += fmt.Sprintf("%s\r\n", field)
+		str += fmt.Sprintf("%s\n", field)
 	}
 	str += "BINARY:\n"
 	str += string(r.Data)


### PR DESCRIPTION
Closes #21 